### PR TITLE
Remove the un-needed reverts + default to gpu comp - fix logcat spam

### DIFF
--- a/libgralloc/alloc_controller.cpp
+++ b/libgralloc/alloc_controller.cpp
@@ -375,8 +375,6 @@ size_t getBufferSizeAndDimensions(int width, int height, int format,
             size += ALIGN( alignedw * ALIGN(height/2, 32), 8192);
             break;
         case HAL_PIXEL_FORMAT_NV12_ENCODEABLE:
-        case HAL_PIXEL_FORMAT_YCbCr_420_SP:
-        case HAL_PIXEL_FORMAT_YCrCb_420_SP:
         case HAL_PIXEL_FORMAT_YV12:
             if ((format == HAL_PIXEL_FORMAT_YV12) && ((width&1) || (height&1))) {
                 ALOGE("w or h is odd for the YV12 format");
@@ -393,6 +391,11 @@ size_t getBufferSizeAndDimensions(int width, int height, int format,
                     (ALIGN(alignedw/2, 16) * (alignedh/2))*2;
             }
             size = ALIGN(size, 4096);
+            break;
+        case HAL_PIXEL_FORMAT_YCbCr_420_SP:
+        case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+            alignedh = height;
+            size = ALIGN((alignedw*alignedh) + (alignedw* alignedh)/2, 4096);
             break;
         case HAL_PIXEL_FORMAT_YCbCr_422_SP:
         case HAL_PIXEL_FORMAT_YCrCb_422_SP:

--- a/libgralloc/framebuffer.cpp
+++ b/libgralloc/framebuffer.cpp
@@ -310,8 +310,8 @@ int mapFrameBufferLocked(struct private_module_t* module)
 
     float xdpi = (info.xres * 25.4f) / info.width;
     float ydpi = (info.yres * 25.4f) / info.height;
-    //The reserved[4] field is used to store FPS by the driver.
-    float fps  = info.reserved[4];
+    //The reserved[3] field is used to store FPS by the driver.
+    float fps  = info.reserved[3] & 0xFF;
 
     ALOGI("using (fd=%d)\n"
           "id           = %s\n"

--- a/libgralloc/gpu.cpp
+++ b/libgralloc/gpu.cpp
@@ -206,7 +206,7 @@ int gpu_context_t::alloc_impl(int w, int h, int format, int usage,
 
     if ((ssize_t)size <= 0)
         return -EINVAL;
-    size = (bufferSize != 0)? bufferSize : size;
+    size = (bufferSize >= size)? bufferSize : size;
 
     // All buffers marked as protected or for external
     // display need to go to overlay

--- a/libhwcomposer/hwc_external.cpp
+++ b/libhwcomposer/hwc_external.cpp
@@ -129,7 +129,7 @@ void disp_mode_timing_type::set_info(struct fb_var_screeninfo &info) const
     info.reserved[0] = 0;
     info.reserved[1] = 0;
     info.reserved[2] = 0;
-    info.reserved[3] = video_format;
+    info.reserved[3] = info.reserved[3] | (video_format << 16);
 
     info.xoffset = 0;
     info.yoffset = 0;

--- a/libqdutils/comptype.h
+++ b/libqdutils/comptype.h
@@ -61,34 +61,22 @@ class QCCompositionType : public Singleton <QCCompositionType>
 inline QCCompositionType::QCCompositionType()
 {
     char property[PROPERTY_VALUE_MAX];
-    mCompositionType = 0;
-    if (property_get("debug.sf.hw", property, NULL) > 0) {
-        if(atoi(property) == 0) {
-            mCompositionType = COMPOSITION_TYPE_CPU;
-        } else { //debug.sf.hw = 1
-            property_get("debug.composition.type", property, NULL);
-            if (property == NULL) {
-                mCompositionType = COMPOSITION_TYPE_GPU;
-            } else if ((strncmp(property, "mdp", 3)) == 0) {
-                mCompositionType = COMPOSITION_TYPE_MDP;
-            } else if ((strncmp(property, "c2d", 3)) == 0) {
-                mCompositionType = COMPOSITION_TYPE_C2D;
-            } else if ((strncmp(property, "dyn", 3)) == 0) {
-                 if (qdutils::MDPVersion::getInstance().getMDPVersion() < 400)
-                     mCompositionType =
-                         COMPOSITION_TYPE_DYN |COMPOSITION_TYPE_MDP;
-                 else
-                     mCompositionType =
-                         COMPOSITION_TYPE_DYN|COMPOSITION_TYPE_C2D;
-            } else {
-                mCompositionType = COMPOSITION_TYPE_GPU;
-            }
+    mCompositionType = COMPOSITION_TYPE_GPU;
+    if (property_get("debug.composition.type", property, "gpu") > 0) {
+        if ((strncmp(property, "mdp", 3)) == 0) {
+            mCompositionType = COMPOSITION_TYPE_MDP;
+        } else if ((strncmp(property, "c2d", 3)) == 0) {
+            mCompositionType = COMPOSITION_TYPE_C2D;
+        } else if ((strncmp(property, "dyn", 3)) == 0) {
+#ifdef USE_MDP3
+            mCompositionType = COMPOSITION_TYPE_DYN | COMPOSITION_TYPE_MDP;
+#else
+            mCompositionType = COMPOSITION_TYPE_DYN | COMPOSITION_TYPE_C2D;
+#endif
         }
-    } else { //debug.sf.hw is not set. Use cpu composition
-        mCompositionType = COMPOSITION_TYPE_CPU;
     }
-
 }
+
 }; //namespace qdutils
 ANDROID_SINGLETON_STATIC_INSTANCE(qdutils::QCCompositionType);
 #endif //INCLUDE_LIBQCOM_COMPTYPES


### PR DESCRIPTION
Re-apply "gralloc : apply kernel 3.4 fb screeninfo type""

This reverts commit c4f8902afdb0cce6b2bdd91a2f0191f9735ccf39.

Re-apply "hwc: Fix reserved field usage""

This reverts commit 80a7d2f900d49e8bf4edf5b8c51c047da1a241e1.

Then also make gpu comp the default. this should fix the logcat spam about hwc in framebuffer target
