### PR TITLE
Allow to setup fps manually

### DIFF
--- a/libgralloc/framebuffer.cpp
+++ b/libgralloc/framebuffer.cpp
@@ -283,7 +283,12 @@ int mapFrameBufferLocked(struct private_module_t* module)
     float xdpi = (info.xres * 25.4f) / info.width;
     float ydpi = (info.yres * 25.4f) / info.height;
     //The reserved[3] field is used to store FPS by the driver.
+#ifndef REFRESH_RATE
     float fps  = info.reserved[3] & 0xFF;
+#else
+    float fps = REFRESH_RATE;
+#endif
+
 
     ALOGI("using (fd=%d)\n"
           "id           = %s\n"


### PR DESCRIPTION
With msm8660 gralloc was reporting 0.00 Hrtz in logcat. with this commit along with the -DREFESH_RATE flag in device tree we can specify the refresh rate manually in this case 60 htz. It seems help performance a lot. Only thing i'm still having issues with is when things slow down to draw text more clearly.
