### PR TITLE
For devices like htc marvel and liberty, some pixel formats aren't suppo...

### DIFF
--- a/liboverlay/overlayMdp.cpp
+++ b/liboverlay/overlayMdp.cpp
@@ -218,11 +218,13 @@ bool MdpCtrl::get() {
 void MdpCtrl::adjustSrcWhf(const bool& rotUsed) {
     if(rotUsed) {
         utils::Whf whf = getSrcWhf();
+#ifndef QCOM_MISSING_PIXEL_FORMATS
         if(whf.format == MDP_Y_CRCB_H2V2_TILE ||
                 whf.format == MDP_Y_CBCR_H2V2_TILE) {
             whf.w = utils::alignup(whf.w, 64);
             whf.h = utils::alignup(whf.h, 32);
         }
+#endif
         //For example: If original format is tiled, rotator outputs non-tiled,
         //so update mdp's src fmt to that.
         whf.format = utils::getRotOutFmt(whf.format);

--- a/liboverlay/overlayUtils.cpp
+++ b/liboverlay/overlayUtils.cpp
@@ -216,24 +216,30 @@ int getMdpFormat(int format) {
             return MDP_RGB_565;
         case HAL_PIXEL_FORMAT_BGRA_8888:
             return MDP_BGRA_8888;
+#ifndef QCOM_MISSING_PIXEL_FORMATS
         case HAL_PIXEL_FORMAT_YV12:
             return MDP_Y_CR_CB_GH2V2;
+#endif
         case HAL_PIXEL_FORMAT_YCbCr_422_SP:
             return MDP_Y_CBCR_H2V1;
         case HAL_PIXEL_FORMAT_YCrCb_420_SP:
             return MDP_Y_CRCB_H2V2;
 
         //From gralloc_priv.h
+#ifndef QCOM_MISSING_PIXEL_FORMATS
         case HAL_PIXEL_FORMAT_YCbCr_420_SP_TILED:
             return MDP_Y_CBCR_H2V2_TILE;
+#endif
         case HAL_PIXEL_FORMAT_YCbCr_420_SP:
             return MDP_Y_CBCR_H2V2;
         case HAL_PIXEL_FORMAT_YCrCb_422_SP:
             return MDP_Y_CRCB_H2V1;
+#ifndef QCOM_MISSING_PIXEL_FORMATS
         case HAL_PIXEL_FORMAT_YCbCr_444_SP:
             return MDP_Y_CBCR_H1V1;
         case HAL_PIXEL_FORMAT_YCrCb_444_SP:
             return MDP_Y_CRCB_H1V1;
+#endif
 
         default:
             //Unsupported by MDP

--- a/liboverlay/overlayUtils.h
+++ b/liboverlay/overlayUtils.h
@@ -481,12 +481,18 @@ inline bool isYuv(uint32_t format) {
         case MDP_Y_CBCR_H2V1:
         case MDP_Y_CBCR_H2V2:
         case MDP_Y_CRCB_H2V2:
+#ifndef QCOM_MISSING_PIXEL_FORMATS
         case MDP_Y_CRCB_H1V1:
+#endif
         case MDP_Y_CRCB_H2V1:
+#ifndef QCOM_MISSING_PIXEL_FORMATS
         case MDP_Y_CRCB_H2V2_TILE:
         case MDP_Y_CBCR_H2V2_TILE:
+#endif
         case MDP_Y_CR_CB_H2V2:
+#ifndef QCOM_MISSING_PIXEL_FORMATS
         case MDP_Y_CR_CB_GH2V2:
+#endif
             return true;
         default:
             return false;
@@ -580,14 +586,18 @@ inline int getMdpOrient(eTransform rotation) {
 
 inline int getRotOutFmt(uint32_t format) {
     switch (format) {
+#ifndef QCOM_MISSING_PIXEL_FORMATS
         case MDP_Y_CRCB_H2V2_TILE:
             return MDP_Y_CRCB_H2V2;
         case MDP_Y_CBCR_H2V2_TILE:
             return MDP_Y_CBCR_H2V2;
+#endif
         case MDP_Y_CB_CR_H2V2:
             return MDP_Y_CBCR_H2V2;
+#ifndef QCOM_MISSING_PIXEL_FORMATS
         case MDP_Y_CR_CB_GH2V2:
             return MDP_Y_CRCB_H2V2;
+#endif
         default:
             return format;
     }


### PR DESCRIPTION
...rted and compile fails

define following in your boardconfig to make use of it
COMMON_GLOBAL_CFLAGS += -DQCOM_MISSING_PIXEL_FORMATS

Commit is derived from http://goo.gl/91KJ9
