### PR TITLE
Fix typos

### DIFF
--- a/libtilerenderer/Android.mk
+++ b/libtilerenderer/Android.mk
@@ -7,7 +7,7 @@ LOCAL_MODULE           := libtilerenderer
 LOCAL_MODULE_TAGS      := optional
 LOCAL_CFLAGS           := -DLOG_TAG=\"qdtilerenderer\"
 LOCAL_C_INCLUDES := \
-        frameworks/base/include/utils \
+        frameworks/native/include/utils \
         frameworks/base/libs/hwui \
         external/skia/include/core \
         external/skia/include/effects \
@@ -15,7 +15,7 @@ LOCAL_C_INCLUDES := \
         external/skia/src/ports \
         external/skia/include/utils \
         hardware/libhardware/include/hardware \
-        frameworks/base/opengl/include/GLES2
+        frameworks/native/opengl/include/GLES2
 LOCAL_SHARED_LIBRARIES := $(common_libs) libGLESv2 libhwui
 LOCAL_SRC_FILES        := tilerenderer.cpp
 


### PR DESCRIPTION
the address are incorrect 

Conflict here 

Libtilerenderer/Android.mk
-        frameworks/base/include/utils \
-        frameworks/native/include/utils \

and here
-        frameworks/base/opengl/include/GLES2
-        frameworks/native/opengl/include/GLES2
